### PR TITLE
Issue #44: Permissive build boots w/SELinux disabled

### DIFF
--- a/kickstart/clip-rhel7/clip-rhel7.ks
+++ b/kickstart/clip-rhel7/clip-rhel7.ks
@@ -312,7 +312,7 @@ plymouth-set-default-theme details --rebuild-initrd &> /dev/null
 ###### START - ADJUST SYSTEM BASED ON BUILD CONFIGURATION VARIABLES ###########
 
 # Set permissive mode
-export POLNAME=`sestatus |awk '/Policy from config file:/ { print $5; }'`
+export POLNAME=`sestatus |awk '/Loaded policy name:/ { print $4; }'`
 if [ x"$CONFIG_BUILD_ENFORCING_MODE" != "xy" ]; then
     echo "Setting permissive mode..."
     echo -e "#THIS IS A DEBUG BUILD HENCE SELINUX IS IN PERMISSIVE MODE\nSELINUX=permissive\nSELINUXTYPE=$POLNAME\n" > /etc/selinux/config


### PR DESCRIPTION
```
Output from sestatus changed from RHEL6 -> RHEL7.
Parse output for loaded policy name to put in /etc/selinux/config
when doing Permissive build. Otherwise system doesn't know path
to policy and boots w/SELinux disabled.
```
