### PR TITLE
Issue #110: Add missing arguments in kickstart regarding AIDE

### DIFF
--- a/kickstart/clip-rhel7/clip-rhel7.ks
+++ b/kickstart/clip-rhel7/clip-rhel7.ks
@@ -348,14 +348,14 @@ $CONTENT_PATH/ssg-rhel7-xccdf.xml
 AIDE_DIR=/var/lib/aide
 
 echo "configuring AIDE"
-/bin/mv $AIDE_DIR/aide.db.new.gz $AIDE_DIR/aide.db.gz
 /bin/mv /sbin/aide $AIDE_DIR/aide
 /bin/mv /etc/aide.conf $AIDE_DIR/aide.conf
 /bin/ln -s $AIDE_DIR/aide /usr/sbin/aide
-/sbin/aide --init
+/sbin/aide --init --config=$AIDE_DIR/aide.conf
+/bin/mv $AIDE_DIR/aide.db.new.gz $AIDE_DIR/aide.db.gz
 
 # run aide cron job daily
-echo "0 1 * * * $AIDE_DIR/aide --check --config=$AIDE/aide.conf" >> /etc/crontab
+echo "0 1 * * * $AIDE_DIR/aide --check --config=$AIDE_DIR/aide.conf" >> /etc/crontab
 
 /bin/sed -ie '/vg00-aide/ s/defaults/ro,defaults/' /etc/fstab
 ### Done with AIDE ###


### PR DESCRIPTION
There were some missing options to our AIDE commands. We were also
moving some files around before they existed. Issue #115 will complete our AIDE
configuration.