### PR TITLE
Issue #114: Don't track pkglist.clip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ tmp
 ./*.rpm
 *.iso
 conf/mock/*.cfg
+conf/pkglist.clip
 repos/yumcache/*
 repodata
 repos/*-repo/*


### PR DESCRIPTION
pkglist.clip is frequently changing because of RPMs that are built from
CLIP. It makes more sense to not track the pkglist.