### PR TITLE
Issue-115: Add AIDE service that runs on first boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,10 @@ kickstart.
 
 #### Configuring AIDE
 
-CLIP runs an AIDE check as the last step during installation. The newly created database, AIDE binary, and aide.conf are then moved to a read-only file system.
-A cron job is executed every 24 hours and writes detected changes to `/var/log/aide.log`. Where the AIDE files are written, the cron job, as well as `aide.conf`, are all configurable in the kickstart script. A typical use case is to disable networking on the system if the cron job fails. Another useful configuration is to write the AIDE files to read-only media that is kept off the box for added security.
+CLIP creates a systemd service unit which runs an AIDE check on first boot. The newly created database, AIDE binary, and aide.conf are moved to a file system which is mounted read-only after a reboot triggered by the AIDE service.
+A cron job is executed every 24 hours and logs detected changes to `/var/log/aide.log`. Where the AIDE files are written, the cron job, as well as `aide.conf`, are all configurable in the kickstart script. A typical use case is to disable networking on the system if the cron job fails. Another useful configuration is to write the AIDE files to read-only media that is kept off the box for added security.
+
+**NOTE:** `aide.conf` has not been modified by CLIP and will need to be configured to ignore files on a case by case basis.
 
 #### Configuring Scap Security Guide
 


### PR DESCRIPTION
This service will run on first boot and runs the AIDE check. The service
will only run once.