### PR TITLE
Issue #141: Remove certain packages in production

### DIFF
--- a/kickstart/clip-rhel7/clip-rhel7.ks
+++ b/kickstart/clip-rhel7/clip-rhel7.ks
@@ -255,14 +255,6 @@ else
 	/sbin/usermod --pass="$HASHED_PASSWORD" "$USERNAME"
 fi
 
-if [ x"$CONFIG_BUILD_PRODUCTION" == "xy" ]; then
-	# Remove sshd and dhclient if it in a production build
-	/bin/echo "Removing sshd, rsync, and dhclient from the system"
-	/bin/rpm -e openssh openssh-clients openssh-server dhclient rsync
-	# Force password reset only for production builds
-	/bin/chage -d 0 "$USERNAME"
-fi
-
 # Add the user to sudoers and setup an SELinux role/type transition.
 # This line enables a transition via sudo instead of requiring sudo and newrole.
 if [ x"$CONFIG_BUILD_UNCONFINED_TOOR" == "xy" ]; then
@@ -385,6 +377,15 @@ EOF
 systemctl enable aide.service
 
 ### Done with AIDE ###
+
+if [ x"$CONFIG_BUILD_PRODUCTION" == "xy" ]; then
+	# Remove sshd and rsync if in a production build
+	/bin/echo "Removing ssh and rsync from the system"
+	/bin/yum remove -y openssh* rsync
+	/bin/rpm -e --nodeps rpm yum
+	# Force password reset only for production builds
+	/bin/chage -d 0 "$USERNAME"
+fi
 
 /bin/kill $TAILPID 2>/dev/null 1>/dev/null
 


### PR DESCRIPTION
Removal of packages should be the last thing done in the first %post
section in the kickstart. We now also remove yum and rpm.