### PR TITLE
Issue #152 - Fix bad variable evaluation

### DIFF
--- a/kickstart/clip-rhel7/clip-rhel7.ks
+++ b/kickstart/clip-rhel7/clip-rhel7.ks
@@ -374,7 +374,7 @@ EOF
 	WantedBy=multi-user.target
 EOF
 
-if [ x"CONFIG_BUILD_AIDE" == "xy" ]; then
+if [ x"$CONFIG_BUILD_AIDE" == "xy" ]; then
 	systemctl enable aide.service
 else
 	systemctl disable aide.service


### PR DESCRIPTION
- Check on value of CONFIG_BUILD_AIDE did not include the $ when
  checking the variable. Fix that.