### PR TITLE
Issue #163: Remove timeout from bootloader

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -233,7 +233,7 @@ if [ x"`cat /sys/fs/selinux/enforce`" == "x1" ]; then
 fi
 
 # Roll lorax
-check_and_build_rpm "lorax" "lorax-19.6.45-5.el7"
+check_and_build_rpm "lorax" "lorax-19.6.45-6.el7"
 
 # Roll pungi
 check_and_build_rpm "pungi" "pungi-2.13-4.el7"

--- a/packages/lorax/Makefile
+++ b/packages/lorax/Makefile
@@ -15,7 +15,7 @@ VERSION := 19.6.45
 
 # bump this if creating multiple releases from the same
 # version (think about this... why are you doing this?)
-RELEASE := 5.el7
+RELEASE := 6.el7
 
 # The name of the Packager
 PACKAGER ?= Tresys Technology

--- a/packages/lorax/lorax-19.6.45/share/config_files/x86/isolinux.cfg
+++ b/packages/lorax/lorax-19.6.45/share/config_files/x86/isolinux.cfg
@@ -1,5 +1,5 @@
 default vesamenu.c32
-timeout 600
+timeout 0
 
 display boot.msg
 


### PR DESCRIPTION
Bump lorax version. This requires running bootstap.sh on existing build
systems.