### PR TITLE
Issue #181: Fix TAR_DEPS variable in clip-dracut-module

### DIFF
--- a/packages/clip-dracut-module/Makefile
+++ b/packages/clip-dracut-module/Makefile
@@ -37,7 +37,7 @@ OUTPUT_DIR ?= $(ROOT_DIR)
 SRPM_OUTPUT_DIR ?= $(OUTPUT_DIR)
 
 # exhaustive list of deps for the RPM, used to determine if RPM needs to be rebuilt
-TAR_DEPS := $(shell find $(PKGNAME)-$(VERSION) -type f -name '*.*')
+TAR_DEPS := $(shell find $(PKGNAME) -type f -name '*.*')
 RPM_DEPS := $(TARBALL) $(RPM_SPEC) $(CURDIR)/Makefile
 
 RPM_TMPDIR ?= $(ROOT_DIR)/tmp


### PR DESCRIPTION
The clip-dracut-module Makefile used the version of the package
when collecting files to track to build the tarball for the src
rpm. Since the clip-dracut-module source directory does not have
a version, the files were not gathered properly. This allows mock
to function correctly and detect code changes that will trigger rebuilding
the RPM when necessary.