### PR TITLE
Add forced password change back into all builds

### DIFF
--- a/kickstart/clip-rhel7/clip-rhel7.ks
+++ b/kickstart/clip-rhel7/clip-rhel7.ks
@@ -392,9 +392,10 @@ if [ x"$CONFIG_BUILD_PRODUCTION" == "xy" ]; then
 	/bin/echo "Removing ssh and rsync from the system"
 	/bin/yum remove -y openssh* rsync
 	/bin/rpm -e --nodeps rpm yum
-	# Force password reset only for production builds
-	/bin/chage -d 0 "$USERNAME"
 fi
+
+# Force password reset
+/bin/chage -d 0 "$USERNAME"
 
 /bin/kill $TAILPID 2>/dev/null 1>/dev/null
 


### PR DESCRIPTION
This gets in the way of properly testing on debug builds. While constantly having to re-enter a password on first boot is a nuisance, it's worth it to make sure we're hitting the same threads between production and non-production.