### PR TITLE
Issue #164: Resolve shutdown_t denials

### DIFF
--- a/packages/clip-selinux-policy/clip-selinux-policy/policy/modules/contrib/shutdown.te
+++ b/packages/clip-selinux-policy/clip-selinux-policy/policy/modules/contrib/shutdown.te
@@ -87,3 +87,10 @@ optional_policy(`
 optional_policy(`
 	xserver_dontaudit_write_log(shutdown_t)
 ')
+
+ifdef(`init_systemd',`
+    kernel_use_fds(shutdown_t)
+    domain_signal_all_domains(shutdown_t)
+    domain_search_all_domains_state(shutdown_t)
+    domain_read_all_domains_state(shutdown_t)
+')


### PR DESCRIPTION
shutdown_t needs permission to look at /proc/ before shutting down.