### PR TITLE
Fail if the build system is in enforcing or SELinux is disabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ endef
 
 define CHECK_DEPS
 	@if ! rpm -q $(HOST_RPM_DEPS) 2>&1 >/dev/null; then echo "Please ensure the following RPMs are installed: $(HOST_RPM_DEPS)."; exit 1; fi
-	@if [ x"`cat /sys/fs/selinux/enforce`" == "x1" ]; then echo -e "This is embarassing but due to a bug (bz #861281) you must do builds in permissive.\nhttps://bugzilla.redhat.com/show_bug.cgi?id=861281" && exit 1; fi
+	@if [ "`getenforce`" != "Permissive" ]; then echo -e "This is embarassing but due to a bug (bz #861281) you must do builds in permissive.\nhttps://bugzilla.redhat.com/show_bug.cgi?id=861281" && exit 1; fi
 endef
 
 define CHECK_MOCK


### PR DESCRIPTION
If the build system has SELinux disabled, LiveCD builds fail.