### PR TITLE
Fix bug in mangage_pkglist's handling of errors from the repo command

### DIFF
--- a/support/manage_pkglist.py
+++ b/support/manage_pkglist.py
@@ -48,10 +48,10 @@ def reqs_to_packages(config, reqs, arch):
 				if pkg_arch not in package_names.keys ():
 					package_names[pkg_arch] = set ()
 				package_names[pkg_arch].add(match[0].strip())
-			rc = repoquery.wait()
-			if rc != 0:
-				print "ERROR: repoquery exited with rc %s: stderr: %s" % (rc, repoquery.stderr.read())
-				raise Exception("ERROR: repoquery exited with rc %s: stderr: %s" % (rc, repoquery.stderr.read()))
+		rc = repoquery.wait()
+		if rc != 0:
+			print "ERROR: repoquery exited with rc %s: stderr: %s" % (rc, repoquery.stderr.read())
+			raise Exception("ERROR: repoquery exited with rc %s: stderr: %s" % (rc, repoquery.stderr.read()))
 
 	if not package_names:
 		print "Unmatched regs: %s" % reqs


### PR DESCRIPTION
Previously, manage_pkglist.py would check for an error code once for each line
of output. Since finding an error causing it to raise an exception, this is fine so
long as there is output. However, if there is no output on stdout, then the check
never happens