### PR TITLE
Some cleanup

### DIFF
--- a/CONFIG_BUILD
+++ b/CONFIG_BUILD
@@ -71,9 +71,9 @@ TARGET_ARCH := $(shell uname -i)
 # If you want to reuse the same chroot for all RPMs, set CLEAN_MOCK to n
 # This should decrease the build time since we won't have to install common
 # packages in the chroot for each RPM
-CLEAN_MOCK := y
+CLEAN_MOCK ?= y
 
 # Quiet down the build output a bit.
-QUIET := n
+QUIET ?= n
 
 export TARGET_ARCH ADDTL_DEPS QUIET CONFIG_BUILD_BASH_VARS CONFIG_BUILD_ENFORCING_MODE CONFIG_BUILD_UNCONFINED_TOOR CONFIG_BUILD_PRODUCTION ISO_VERSION ENABLE_NETWORKING CONFIG_BUILD_AIDE CONFIG_BUILD_FIPS_MODE CONFIG_REMOVE_SCAP

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ REPO_LINK := /bin/ln -s
 REPO_WGET := /usr/bin/wget
 REPO_CREATE := /usr/bin/createrepo -d --workers $(shell /usr/bin/nproc) -c $(REPO_DIR)/yumcache
 REPO_QUERY :=  repoquery -c $(YUM_CONF_FILE) --quiet -a --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}.rpm'
-MOCK_ARGS += --resultdir=$(CLIP_REPO_DIR) -r $(MOCK_CONF_DIR)/$(MOCK_REL_INSTANCE).cfg --configdir=$(MOCK_CONF_DIR) --unpriv --rebuild
+MOCK_ARGS += --resultdir=$(CLIP_REPO_DIR) --root=$(MOCK_CONF_DIR)/$(MOCK_REL_INSTANCE).cfg --configdir=$(MOCK_CONF_DIR) --unpriv --rebuild
 ifeq ($(CLEAN_MOCK),n)
     MOCK_ARGS += --no-clean --no-cleanup-after
 endif

--- a/packages/clip-lockdown/Makefile
+++ b/packages/clip-lockdown/Makefile
@@ -88,7 +88,7 @@ $(SRPM_OUTPUT_DIR)/$(PKGNAME)-$(VERSION)-$(RELEASE).src.rpm: $(RPM_DEPS)
 	@echo "Building $(PKGNAME) SRPM..."
 	$(call rpm-prep)
 	cp $(TARBALL) $(RPM_TOPDIR)/SOURCES/
-	echo -e "%define pkgname $(PKGNAME)\n%define _sysconfdir /etc\n%define version $(VERSION)\n%define release $(RELEASE)\n%define vendor $(VENDOR)\n%define packager $(PACKAGER)\nBuildArch: $(ARCH)\n"> $(RPM_TOPDIR)/SPECS/$(notdir $(RPM_SPEC))
+	echo -e "%define pkgname $(PKGNAME)\n%define version $(VERSION)\n%define release $(RELEASE)\n%define vendor $(VENDOR)\n%define packager $(PACKAGER)\nBuildArch: $(ARCH)\n"> $(RPM_TOPDIR)/SPECS/$(notdir $(RPM_SPEC))
 	cat $(RPM_SPEC) >> $(RPM_TOPDIR)/SPECS/$(notdir $(RPM_SPEC))
 	cd $(RPM_TOPDIR) && rpmbuild $(RPMBUILD_ARGS) -bs SPECS/$(notdir $(RPM_SPEC)) --nodeps
 	mv  $(RPM_TOPDIR)/SRPMS/$(PKGNAME)-$(VERSION)-$(RELEASE).src.rpm $(SRPM_OUTPUT_DIR)

--- a/packages/clip-lockdown/clip-lockdown/audit/50-clip-access.rules
+++ b/packages/clip-lockdown/clip-lockdown/audit/50-clip-access.rules
@@ -1,4 +1,0 @@
-
--a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail
-
-

--- a/packages/clip-selinux-policy/Makefile
+++ b/packages/clip-selinux-policy/Makefile
@@ -87,7 +87,7 @@ else
 	ENABLE_BASE += oscap
 endif
 
-RPMQ_DEFS := --query --define 'pkgname $(PKGNAME)' --define '_sysconfdir /etc' --define 'version $(VERSION)' --define 'release $(RELEASE)' --define 'vendor $(VENDOR)' --define 'packager $(PACKAGER)' --qf '%{NAME}\n'
+RPMQ_DEFS := --query --define 'pkgname $(PKGNAME)' --define 'version $(VERSION)' --define 'release $(RELEASE)' --define 'vendor $(VENDOR)' --define 'packager $(PACKAGER)' --qf '%{NAME}\n'
 
 ifneq ($(ENABLE_MODULES),)
 RPM_DEFS := --define 'enable_modules $(ENABLE_MODULES)' $(RPM_DEFS)
@@ -129,7 +129,6 @@ $(SRPM_OUTPUT_DIR)/$(PKGNAME)-$(VERSION)-$(RELEASE).src.rpm: $(RPM_DEPS)
 	echo "%define enable_modules $(ENABLE_MODULES)" >> $(RPM_TOPDIR)/SPECS/$(notdir $(RPM_SPEC))
 	echo "%define enforcing_mode $(ENFORCING_MODE)" >> $(RPM_TOPDIR)/SPECS/$(notdir $(RPM_SPEC))
 	echo "%define pkgname $(PKGNAME)" >> $(RPM_TOPDIR)/SPECS/$(notdir $(RPM_SPEC))
-	echo "%define _sysconfdir /etc" >> $(RPM_TOPDIR)/SPECS/$(notdir $(RPM_SPEC))
 	echo "%define version $(VERSION)" >> $(RPM_TOPDIR)/SPECS/$(notdir $(RPM_SPEC))
 	echo "%define release $(RELEASE)" >> $(RPM_TOPDIR)/SPECS/$(notdir $(RPM_SPEC))
 	echo "%define vendor $(VENDOR)" >> $(RPM_TOPDIR)/SPECS/$(notdir $(RPM_SPEC))

--- a/packages/examples/source/Makefile.tmpl
+++ b/packages/examples/source/Makefile.tmpl
@@ -87,7 +87,7 @@ $(OUTPUT_DIR)/$(PKGNAME)-$(VERSION)-$(RELEASE).$(ARCH).rpm: $(SRPM_OUTPUT_DIR)/$
 $(SRPM_OUTPUT_DIR)/$(PKGNAME)-$(VERSION)-$(RELEASE).src.rpm: $(RPM_DEPS)
 	@echo "Building $(PKGNAME) SRPM..."
 	$(call rpm-prep)
-	echo -e "%define pkgname $(PKGNAME)\n%define _sysconfdir /etc\n%define version $(VERSION)\n%define release $(RELEASE)\n%define vendor $(VENDOR)\n%define packager $(PACKAGER)\nBuildArch: $(ARCH)\n"> $(RPM_TOPDIR)/SPECS/$(notdir $(RPM_SPEC))
+	echo -e "%define pkgname $(PKGNAME)\n%define version $(VERSION)\n%define release $(RELEASE)\n%define vendor $(VENDOR)\n%define packager $(PACKAGER)\nBuildArch: $(ARCH)\n"> $(RPM_TOPDIR)/SPECS/$(notdir $(RPM_SPEC))
 	cat $(RPM_SPEC) >> $(RPM_TOPDIR)/SPECS/$(notdir $(RPM_SPEC))
 	cd $(RPM_TOPDIR) && rpmbuild $(RPMBUILD_ARGS) -bs SPECS/$(notdir $(RPM_SPEC)) --nodeps
 	mv  $(RPM_TOPDIR)/SRPMS/$(PKGNAME)-$(VERSION)-$(RELEASE).src.rpm $(SRPM_OUTPUT_DIR)

--- a/packages/examples/srcrpm_patching/Makefile
+++ b/packages/examples/srcrpm_patching/Makefile
@@ -78,7 +78,7 @@ $(SRPM_OUTPUT_DIR)/$(PKGNAME)-$(VERSION)-$(RELEASE).src.rpm: $(RPM_DEPS)
 	@echo "Building $(PKGNAME) SRPM..."
 	$(call rpm-prep)
 	cp $(SOURCES) $(RPM_TOPDIR)/SOURCES/
-	echo -e "%define pkgname $(PKGNAME)\n%define _sysconfdir /etc\n%define version $(VERSION)\n%define release $(RELEASE)\n%define vendor $(VENDOR)\n%define packager $(PACKAGER)\nBuildArch: $(ARCH)\n" > $(RPM_TOPDIR)/SPECS/$(notdir $(RPM_SPEC))
+	echo -e "%define pkgname $(PKGNAME)\n%define version $(VERSION)\n%define release $(RELEASE)\n%define vendor $(VENDOR)\n%define packager $(PACKAGER)\nBuildArch: $(ARCH)\n" > $(RPM_TOPDIR)/SPECS/$(notdir $(RPM_SPEC))
 	cat $(RPM_SPEC) >> $(RPM_TOPDIR)/SPECS/$(notdir $(RPM_SPEC))
 	cd $(RPM_TOPDIR) && rpmbuild $(RPMBUILD_ARGS) -bs SPECS/$(notdir $(RPM_SPEC)) --nodeps
 	mv  $(RPM_TOPDIR)/SRPMS/$(PKGNAME)-$(VERSION)-$(RELEASE).src.rpm $(SRPM_OUTPUT_DIR)

--- a/packages/webpageexample/Makefile
+++ b/packages/webpageexample/Makefile
@@ -86,7 +86,7 @@ $(OUTPUT_DIR)/$(PKGNAME)-$(VERSION)-$(RELEASE).$(ARCH).rpm: $(SRPM_OUTPUT_DIR)/$
 $(SRPM_OUTPUT_DIR)/$(PKGNAME)-$(VERSION)-$(RELEASE).src.rpm: $(RPM_DEPS)
 	@echo "Building $(PKGNAME) SRPM..."
 	$(call rpm-prep)
-	echo -e "%define pkgname $(PKGNAME)\n%define _sysconfdir /etc\n%define version $(VERSION)\n%define release $(RELEASE)\n%define vendor $(VENDOR)\n%define packager $(PACKAGER)\nBuildArch: $(ARCH)\n"> $(RPM_TOPDIR)/SPECS/$(notdir $(RPM_SPEC))
+	echo -e "%define pkgname $(PKGNAME)\n%define version $(VERSION)\n%define release $(RELEASE)\n%define vendor $(VENDOR)\n%define packager $(PACKAGER)\nBuildArch: $(ARCH)\n"> $(RPM_TOPDIR)/SPECS/$(notdir $(RPM_SPEC))
 	cat $(RPM_SPEC) >> $(RPM_TOPDIR)/SPECS/$(notdir $(RPM_SPEC))
 	cd $(RPM_TOPDIR) && rpmbuild $(RPMBUILD_ARGS) -bs SPECS/$(notdir $(RPM_SPEC)) --nodeps
 	mv  $(RPM_TOPDIR)/SRPMS/$(PKGNAME)-$(VERSION)-$(RELEASE).src.rpm $(SRPM_OUTPUT_DIR)


### PR DESCRIPTION
Some cleanup - the real important commit is removing 50-clip-access.rules, turns out this rule is now (or has been?) in 30-ospp-42.rules provided by audit rpm so this was causing augenrules to complain about a duplicate.  The other changes are things that have been sitting in my local for a while.