### PR TITLE
Updates to have better results for scap CIS profile

### DIFF
--- a/packages/clip-lockdown/clip-lockdown.spec
+++ b/packages/clip-lockdown/clip-lockdown.spec
@@ -107,6 +107,21 @@ replace_or_append '/etc/audit/auditd.conf' '^space_left' 100 'CCE-80537-4' '%s =
 # Configure auditd to use audispd's syslog plugin
 replace_or_append '/etc/audisp/plugins.d/syslog.conf' '^active' "yes" "CCE-27341-7" '%s = %s'
 
+# set permissions for cron directories as specified by CIS profile
+%triggerin -- crontabs
+# CCE-82229-6
+/usr/bin/chmod 0700 /etc/cron.hourly
+# CCE-82239-5 
+/usr/bin/chmod 0700 /etc/cron.daily
+# CCE-82262-7
+/usr/bin/chmod 0700 /etc/cron.monthly
+# CCE-82250-2
+/usr/bin/chmod 0700 /etc/cron.weekly
+# CCE-82276-7
+/usr/bin/chmod 0700 /etc/cron.d
+
+# CCE-82205-6
+/usr/bin/chmod 0600 /etc/crontab
 
 %triggerin -- filesystem
 /bin/chmod 750 /var/log
@@ -493,6 +508,12 @@ for config_file in "/etc/chrony.conf" "/etc/ntp.conf"; do
 	# Add maxpoll to server entries with the right value
 	/bin/sed -i "/^server/ s/$/ maxpoll $var_time_service_set_maxpoll/" "$config_file"
 done
+
+# CCE-82878-0
+# run chronyd as user 'chrony' (which is default anyway)
+if [ -e "/etc/sysconfig/chronyd" ]; then
+	/bin/sed -i 's/^OPTIONS=\"\([^"]*\)\"/OPTIONS=\"-u chrony \1\"/' /etc/sysconfig/chronyd
+fi
 
 %clean
 rm -rf %{buildroot}

--- a/packages/clip-lockdown/clip-lockdown/audit/50-clip-selinux.rules
+++ b/packages/clip-lockdown/clip-lockdown/audit/50-clip-selinux.rules
@@ -4,3 +4,4 @@
 -a always,exit -F path=/usr/sbin/restorecon -F auid>=1000 -F auid!=unset -F key=privileged-priv_change
 -a always,exit -F path=/usr/sbin/seunshare -F auid>=1000 -F auid!=unset -F key=privileged-priv_change
 
+-w /etc/selinux/ -p wa -k MAC-policy

--- a/packages/clip-lockdown/clip-lockdown/audit/50-clip-session.rules
+++ b/packages/clip-lockdown/clip-lockdown/audit/50-clip-session.rules
@@ -1,0 +1,6 @@
+
+# Required by CIS scap profile - xccdf_org.ssgproject.content_rule_audit_rules_session_events
+# CCE-27301-1
+-w /var/run/utmp -p wa -k session
+-w /var/log/btmp -p wa -k session
+-w /var/log/wtmp -p wa -k session

--- a/packages/clip-lockdown/clip-lockdown/modprobe/freevxfs.conf
+++ b/packages/clip-lockdown/clip-lockdown/modprobe/freevxfs.conf
@@ -1,0 +1,4 @@
+# XCCDF rule: xccdf_org.ssgproject.content_rule_kernel_module_freevxfs_disabled
+# CCE-80138-1
+# disable freevxfs
+install freevxfs /bin/true

--- a/packages/clip-lockdown/clip-lockdown/modprobe/hfs.conf
+++ b/packages/clip-lockdown/clip-lockdown/modprobe/hfs.conf
@@ -1,0 +1,9 @@
+# XCCDF rule: xccdf_org.ssgproject.content_rule_kernel_module_hfs_disabled
+# CCE-80140-7
+# disable hfs
+install hfs /bin/true
+
+# XCCDF rule: xccdf_org.ssgproject.content_rule_kernel_module_hfsplus_disabled
+# CCE-80141-5
+# disable hfsplus
+install hfsplus /bin/true

--- a/packages/clip-lockdown/clip-lockdown/modprobe/jffs2.conf
+++ b/packages/clip-lockdown/clip-lockdown/modprobe/jffs2.conf
@@ -1,0 +1,4 @@
+# XCCDF rule: xccdf_org.ssgproject.content_rule_kernel_module_jffs2_disabled
+# CCE-80139-9
+# disable jffs2
+install jffs2 /bin/true

--- a/packages/clip-lockdown/clip-lockdown/modprobe/squashfs.conf
+++ b/packages/clip-lockdown/clip-lockdown/modprobe/squashfs.conf
@@ -1,0 +1,4 @@
+# XCCDF rule: xccdf_org.ssgproject.content_rule_kernel_module_squashfs_disabled
+# CCE-80142-3
+# disable squashfs
+install squashfs /bin/true

--- a/packages/clip-lockdown/clip-lockdown/modprobe/udf.conf
+++ b/packages/clip-lockdown/clip-lockdown/modprobe/udf.conf
@@ -1,0 +1,4 @@
+# XCCDF rule: xccdf_org.ssgproject.content_rule_kernel_module_udf_disabled
+# CCE-80143-1
+# disable udf
+install udf /bin/true

--- a/packages/clip-lockdown/clip-lockdown/modprobe/vfat.conf
+++ b/packages/clip-lockdown/clip-lockdown/modprobe/vfat.conf
@@ -1,0 +1,4 @@
+# XCCDF rule: xccdf_org.ssgproject.content_rule_kernel_module_vfat_disabled
+# CCE-82169-4
+# disable vfat
+install vfat /bin/true

--- a/packages/clip-selinux-policy/clip-selinux-policy/policy/modules/apps/oscap.te
+++ b/packages/clip-selinux-policy/clip-selinux-policy/policy/modules/apps/oscap.te
@@ -84,6 +84,9 @@ allow oscap_probe_t oscap_t:lnk_file { read_lnk_file_perms };
 logging_send_syslog_msg(oscap_probe_t)
 kernel_getattr_core_if(oscap_probe_t)
 
+# probe selinux booleans
+selinux_get_all_booleans(oscap_probe_t)
+
 # probe_file, probe_textfilecontent
 files_getattr_all_pipes(oscap_probe_t)
 files_getattr_all_sockets(oscap_probe_t)


### PR DESCRIPTION
Following denials due to checking booleans
2021-12-07T14:53:53-05:00 localhost root: type=AVC msg=audit(1638887599.864:555): avc:  denied  { getattr } for  pid=29034 comm="probe_file" path="/sys/fs/selinux/booleans/user_udp_server" dev="selinuxfs" ino=33554508 scontext=system_u:system_r:oscap_probe_t:s0 tcontext=system_u:object_r:boolean_t:s0 tclass=file permissive=1
2021-12-07T14:53:53-05:00 localhost root: type=AVC msg=audit(1638887599.864:556): avc:  denied  { getattr } for  pid=29034 comm="probe_file" path="/sys/fs/selinux/booleans/secure_mode_policyload" dev="selinuxfs" ino=33554471 scontext=system_u:system_r:oscap_probe_t:s0 tcontext=system_u:object_r:secure_mode_policyload_t:s0 tclass=file permissive=1